### PR TITLE
chore(bower.json): add iron-component-page

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
     "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "paper-checkbox": "PolymerElements/paper-checkbox#^1.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }


### PR DESCRIPTION
`Iron-component-page` was missing, so the index.html appeared in blank without the basic information about the component.
